### PR TITLE
test: add first unit test suite (76 tests across 10 fire risk modules)

### DIFF
--- a/src/lib/modules/angstrom/mod.rs
+++ b/src/lib/modules/angstrom/mod.rs
@@ -1,3 +1,6 @@
 pub mod constants;
 pub mod functions;
 pub mod models;
+
+#[cfg(test)]
+mod tests;

--- a/src/lib/modules/angstrom/tests.rs
+++ b/src/lib/modules/angstrom/tests.rs
@@ -1,0 +1,63 @@
+#[cfg(test)]
+mod tests {
+    use super::super::functions::{angstrom_index, get_output_fn};
+    use super::super::models::AngstromStateElement;
+    use super::super::constants::NODATAVAL;
+    use crate::constants::NODATAVAL as OUTPUT_NODATAVAL;
+
+    #[test]
+    fn test_angstrom_index_typical() {
+        // humidity=40%, temp=20°C -> (40/20) + (27-20)/10 = 2.0 + 0.7 = 2.7
+        let result = angstrom_index(20.0, 40.0);
+        assert!((result - 2.7).abs() < 1e-5, "Expected ~2.7, got {}", result);
+    }
+
+    #[test]
+    fn test_angstrom_index_high_fire_risk() {
+        // Low humidity and high temperature -> low angstrom index (high risk)
+        let result = angstrom_index(35.0, 10.0);
+        // (10/20) + (27-35)/10 = 0.5 + (-0.8) = -0.3
+        assert!((result - (-0.3)).abs() < 1e-5, "Expected ~-0.3, got {}", result);
+    }
+
+    #[test]
+    fn test_angstrom_index_low_fire_risk() {
+        // High humidity and low temperature -> high angstrom index (low risk)
+        let result = angstrom_index(5.0, 80.0);
+        // (80/20) + (27-5)/10 = 4.0 + 2.2 = 6.2
+        assert!((result - 6.2).abs() < 1e-5, "Expected ~6.2, got {}", result);
+    }
+
+    #[test]
+    fn test_get_output_fn_valid() {
+        let state = AngstromStateElement {
+            temp: 20.0,
+            humidity: 40.0,
+        };
+        let output = get_output_fn(&state);
+        assert!((output.angstrom - 2.7).abs() < 1e-5);
+        assert!((output.temperature - 20.0).abs() < 1e-5);
+        assert!((output.humidity - 40.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_get_output_fn_nodata_temp() {
+        let state = AngstromStateElement {
+            temp: NODATAVAL,
+            humidity: 40.0,
+        };
+        let output = get_output_fn(&state);
+        // Should return default (NODATAVAL) output when data is missing
+        assert_eq!(output.angstrom, OUTPUT_NODATAVAL);
+    }
+
+    #[test]
+    fn test_get_output_fn_nodata_humidity() {
+        let state = AngstromStateElement {
+            temp: 20.0,
+            humidity: NODATAVAL,
+        };
+        let output = get_output_fn(&state);
+        assert_eq!(output.angstrom, OUTPUT_NODATAVAL);
+    }
+}

--- a/src/lib/modules/fosberg/mod.rs
+++ b/src/lib/modules/fosberg/mod.rs
@@ -1,3 +1,6 @@
 pub mod constants;
 pub mod functions;
 pub mod models;
+
+#[cfg(test)]
+mod tests;

--- a/src/lib/modules/fosberg/tests.rs
+++ b/src/lib/modules/fosberg/tests.rs
@@ -1,0 +1,81 @@
+#[cfg(test)]
+mod tests {
+    use super::super::functions::{emc, ffwi, get_output_fn};
+    use super::super::models::FosbergStateElement;
+    use super::super::constants::NODATAVAL;
+    use crate::constants::NODATAVAL as OUTPUT_NODATAVAL;
+
+    #[test]
+    fn test_emc_low_humidity() {
+        // humidity < 10%
+        let result = emc(20.0, 5.0);
+        // temp_f = 20 * 9/5 + 32 = 68.0
+        // emc = 0.03229 + 0.281073 * 5 - 0.000578 * 68 * 5
+        let expected = 0.03229 + 0.281073 * 5.0 - 0.000578 * 68.0 * 5.0;
+        assert!((result - expected).abs() < 1e-4, "Expected ~{}, got {}", expected, result);
+    }
+
+    #[test]
+    fn test_emc_mid_humidity() {
+        // humidity in [10, 50)
+        let result = emc(25.0, 30.0);
+        // temp_f = 25 * 9/5 + 32 = 77.0
+        // emc = 2.22749 + 0.160107 * 30 - 0.01478 * 77
+        let expected = 2.22749 + 0.160107 * 30.0 - 0.01478 * 77.0;
+        assert!((result - expected).abs() < 1e-4, "Expected ~{}, got {}", expected, result);
+    }
+
+    #[test]
+    fn test_emc_high_humidity() {
+        // humidity >= 50%
+        let result = emc(15.0, 70.0);
+        // temp_f = 15 * 9/5 + 32 = 59.0
+        // emc = 21.0606 + 0.005565 * 70^2 - 0.00035 * 59 * 70 - 0.483199 * 70
+        let expected = 21.0606 + 0.005565 * 70.0f32.powi(2) - 0.00035 * 59.0 * 70.0 - 0.483199 * 70.0;
+        assert!((result - expected).abs() < 1e-3, "Expected ~{}, got {}", expected, result);
+    }
+
+    #[test]
+    fn test_ffwi_clamp_min() {
+        // Very high humidity -> ffwi should be clamped to 0
+        let result = ffwi(5.0, 95.0, 0.0);
+        assert!(result >= 0.0, "ffwi should be >= 0, got {}", result);
+    }
+
+    #[test]
+    fn test_ffwi_clamp_max() {
+        // Extreme conditions -> ffwi should be clamped to 100
+        let result = ffwi(45.0, 2.0, 200000.0);
+        assert!(result <= 100.0, "ffwi should be <= 100, got {}", result);
+    }
+
+    #[test]
+    fn test_ffwi_moderate_conditions() {
+        // Moderate conditions -> ffwi should be in [0, 100]
+        let result = ffwi(25.0, 30.0, 3600.0);
+        assert!(result >= 0.0 && result <= 100.0, "ffwi should be in [0, 100], got {}", result);
+    }
+
+    #[test]
+    fn test_get_output_fn_valid() {
+        let state = FosbergStateElement {
+            temp: 25.0,
+            humidity: 30.0,
+            wind_speed: 3600.0, // 1 m/s in m/h
+        };
+        let output = get_output_fn(&state);
+        assert!(output.ffwi >= 0.0 && output.ffwi <= 100.0);
+        assert!((output.wind_speed - 1.0).abs() < 1e-5); // should be converted to m/s
+    }
+
+    #[test]
+    fn test_get_output_fn_nodata() {
+        let state = FosbergStateElement {
+            temp: NODATAVAL,
+            humidity: 30.0,
+            wind_speed: 3600.0,
+        };
+        let output = get_output_fn(&state);
+        assert_eq!(output.ffwi, OUTPUT_NODATAVAL);
+    }
+}

--- a/src/lib/modules/fwi/mod.rs
+++ b/src/lib/modules/fwi/mod.rs
@@ -2,3 +2,7 @@ pub mod constants;
 pub mod functions;
 pub mod models;
 pub mod config;
+
+
+#[cfg(test)]
+mod tests;

--- a/src/lib/modules/fwi/tests.rs
+++ b/src/lib/modules/fwi/tests.rs
@@ -1,0 +1,166 @@
+#[cfg(test)]
+mod tests {
+    use super::super::functions::{
+        from_ffmc_to_moisture, from_moisture_to_ffmc,
+        moisture_rain_effect, compute_isi, compute_bui, compute_fwi, compute_ifwi,
+        dmc_rain_effect, update_dmc, dc_rain_effect, update_dc,
+    };
+
+    // --- FFMC conversion round-trips ---
+
+    #[test]
+    fn test_ffmc_moisture_roundtrip() {
+        // Converting ffmc -> moisture -> ffmc should give back the original value
+        let ffmc_init = 85.0;
+        let moisture = from_ffmc_to_moisture(ffmc_init);
+        let ffmc_back = from_moisture_to_ffmc(moisture);
+        assert!((ffmc_init - ffmc_back).abs() < 0.1, "Round-trip failed: {} -> {} -> {}", ffmc_init, moisture, ffmc_back);
+    }
+
+    #[test]
+    fn test_ffmc_to_moisture_range() {
+        // FFMC in [0, 101] -> moisture in [0, 250]
+        for ffmc in [0.0_f32, 50.0, 85.0, 101.0] {
+            let m = from_ffmc_to_moisture(ffmc);
+            assert!(m >= 0.0, "Moisture should be >= 0 for ffmc={}, got {}", ffmc, m);
+        }
+    }
+
+    #[test]
+    fn test_moisture_rain_effect_increases_moisture() {
+        // Rain should increase moisture content
+        let moisture_init = 50.0;
+        let result = moisture_rain_effect(moisture_init, 10.0);
+        assert!(result > moisture_init, "Rain should increase moisture, got {}", result);
+    }
+
+    #[test]
+    fn test_moisture_rain_effect_clamped() {
+        // Result should be clamped to [0, 250]
+        let result = moisture_rain_effect(200.0, 100.0);
+        assert!(result <= 250.0 && result >= 0.0, "Expected [0, 250], got {}", result);
+    }
+
+    // --- DMC tests ---
+
+    #[test]
+    fn test_dmc_rain_effect_reduces_dmc() {
+        // Heavy rain -> DMC decreases
+        let dmc_init = 50.0;
+        let result = dmc_rain_effect(dmc_init, 20.0);
+        assert!(result < dmc_init, "Rain should reduce DMC, got {}", result);
+    }
+
+    #[test]
+    fn test_update_dmc_no_rain_warm() {
+        // No rain, warm temp -> DMC increases
+        let dmc_init = 20.0;
+        let result = update_dmc(dmc_init, 0.0, 25.0, 40.0, 9.0);
+        assert!(result > dmc_init, "Warm dry day should increase DMC");
+    }
+
+    #[test]
+    fn test_update_dmc_non_negative() {
+        // DMC should never go negative
+        let result = update_dmc(0.0, 50.0, 25.0, 40.0, 9.0);
+        assert!(result >= 0.0, "DMC should be >= 0, got {}", result);
+    }
+
+    // --- DC tests ---
+
+    #[test]
+    fn test_dc_rain_effect_reduces_dc() {
+        let dc_init = 200.0;
+        let result = dc_rain_effect(dc_init, 30.0);
+        assert!(result < dc_init, "Rain should reduce DC, got {}", result);
+    }
+
+    #[test]
+    fn test_update_dc_no_rain_warm() {
+        // No rain, warm temp -> DC increases
+        let dc_init = 100.0;
+        let result = update_dc(dc_init, 0.0, 25.0, 5.0);
+        assert!(result > dc_init, "Warm dry day should increase DC");
+    }
+
+    // --- ISI tests ---
+
+    #[test]
+    fn test_isi_increases_with_wind() {
+        let isi_calm = compute_isi(80.0, 5000.0);
+        let isi_windy = compute_isi(80.0, 50000.0);
+        assert!(isi_windy > isi_calm, "ISI should increase with wind speed");
+    }
+
+    #[test]
+    fn test_isi_decreases_with_moisture() {
+        let isi_dry = compute_isi(20.0, 20000.0);
+        let isi_wet = compute_isi(150.0, 20000.0);
+        assert!(isi_dry > isi_wet, "ISI should decrease with higher moisture");
+    }
+
+    // --- BUI tests ---
+
+    #[test]
+    fn test_bui_zero_dmc() {
+        // When DMC is 0, BUI should be 0
+        let result = compute_bui(0.0, 100.0);
+        assert_eq!(result, 0.0, "BUI should be 0 when DMC is 0");
+    }
+
+    #[test]
+    fn test_bui_positive() {
+        let result = compute_bui(30.0, 100.0);
+        assert!(result > 0.0, "BUI should be positive, got {}", result);
+    }
+
+    #[test]
+    fn test_bui_non_negative() {
+        let result = compute_bui(5.0, 500.0);
+        assert!(result >= 0.0, "BUI should be non-negative, got {}", result);
+    }
+
+    // --- FWI tests ---
+
+    #[test]
+    fn test_fwi_increases_with_bui() {
+        let fwi_low = compute_fwi(10.0, 5.0);
+        let fwi_high = compute_fwi(100.0, 5.0);
+        assert!(fwi_high > fwi_low, "FWI should increase with BUI");
+    }
+
+    #[test]
+    fn test_fwi_increases_with_isi() {
+        let fwi_low = compute_fwi(50.0, 1.0);
+        let fwi_high = compute_fwi(50.0, 20.0);
+        assert!(fwi_high > fwi_low, "FWI should increase with ISI");
+    }
+
+    #[test]
+    fn test_fwi_non_negative() {
+        let result = compute_fwi(0.0, 0.0);
+        assert!(result >= 0.0, "FWI should be non-negative, got {}", result);
+    }
+
+    // --- IFWI tests ---
+
+    #[test]
+    fn test_ifwi_zero_when_fwi_le_one() {
+        // When FWI <= 1, IFWI should be 0
+        let result = compute_ifwi(0.5);
+        assert_eq!(result, 0.0, "IFWI should be 0 when FWI <= 1");
+    }
+
+    #[test]
+    fn test_ifwi_positive_when_fwi_gt_one() {
+        let result = compute_ifwi(10.0);
+        assert!(result > 0.0, "IFWI should be positive when FWI > 1, got {}", result);
+    }
+
+    #[test]
+    fn test_ifwi_increases_with_fwi() {
+        let ifwi_low = compute_ifwi(5.0);
+        let ifwi_high = compute_ifwi(50.0);
+        assert!(ifwi_high > ifwi_low, "IFWI should increase with FWI");
+    }
+}

--- a/src/lib/modules/hdw/mod.rs
+++ b/src/lib/modules/hdw/mod.rs
@@ -1,3 +1,6 @@
 pub mod constants;
 pub mod functions;
 pub mod models;
+
+#[cfg(test)]
+mod tests;

--- a/src/lib/modules/hdw/tests.rs
+++ b/src/lib/modules/hdw/tests.rs
@@ -1,0 +1,61 @@
+#[cfg(test)]
+mod tests {
+    use super::super::functions::{hdw, get_output_fn};
+    use super::super::models::HdwStateElement;
+    use super::super::constants::NODATAVAL;
+    use crate::constants::NODATAVAL as OUTPUT_NODATAVAL;
+
+    #[test]
+    fn test_hdw_zero_wind() {
+        // With zero wind speed, HDW should be 0
+        let result = hdw(10.0, 0.0);
+        assert_eq!(result, 0.0);
+    }
+
+    #[test]
+    fn test_hdw_typical() {
+        // vpd=10 hPa, wind_speed=3600 m/h (=1 m/s) -> hdw = 1.0 * 10.0 = 10.0
+        let result = hdw(10.0, 3600.0);
+        assert!((result - 10.0).abs() < 1e-4, "Expected ~10.0, got {}", result);
+    }
+
+    #[test]
+    fn test_hdw_high_conditions() {
+        // Higher vpd and wind -> higher HDW
+        let result_high = hdw(20.0, 7200.0);
+        let result_low = hdw(5.0, 3600.0);
+        assert!(result_high > result_low, "Higher vpd/wind should give higher HDW");
+    }
+
+    #[test]
+    fn test_get_output_fn_valid() {
+        let state = HdwStateElement {
+            vpd: 10.0,
+            wind_speed: 3600.0,
+        };
+        let output = get_output_fn(&state);
+        assert!((output.hdw - 10.0).abs() < 1e-4);
+        assert!((output.wind_speed - 1.0).abs() < 1e-5); // converted to m/s
+        assert!((output.vpd - 10.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_get_output_fn_nodata_vpd() {
+        let state = HdwStateElement {
+            vpd: NODATAVAL,
+            wind_speed: 3600.0,
+        };
+        let output = get_output_fn(&state);
+        assert_eq!(output.hdw, OUTPUT_NODATAVAL);
+    }
+
+    #[test]
+    fn test_get_output_fn_nodata_wind() {
+        let state = HdwStateElement {
+            vpd: 10.0,
+            wind_speed: NODATAVAL,
+        };
+        let output = get_output_fn(&state);
+        assert_eq!(output.hdw, OUTPUT_NODATAVAL);
+    }
+}

--- a/src/lib/modules/kbdi/mod.rs
+++ b/src/lib/modules/kbdi/mod.rs
@@ -1,4 +1,8 @@
 pub mod constants;
 pub mod functions;
 pub mod models;
+
 pub mod config;
+
+#[cfg(test)]
+mod tests;

--- a/src/lib/modules/kbdi/tests.rs
+++ b/src/lib/modules/kbdi/tests.rs
@@ -1,0 +1,43 @@
+#[cfg(test)]
+mod tests {
+    use super::super::functions::{kbdi_update_mm};
+    use super::super::constants::NODATAVAL;
+
+    #[test]
+    fn test_kbdi_clamp_min() {
+        // With heavy rain, KBDI should decrease and clamp to 0
+        let result = kbdi_update_mm(10.0, 30.0, &[0.0, 50.0], 800.0);
+        assert!(result >= 0.0, "KBDI should be >= 0, got {}", result);
+    }
+
+    #[test]
+    fn test_kbdi_clamp_max() {
+        // With very high temperature and no rain, KBDI should clamp to 200
+        let result = kbdi_update_mm(199.0, 45.0, &[0.0, 0.0], 300.0);
+        assert!(result <= 200.0, "KBDI should be <= 200, got {}", result);
+    }
+
+    #[test]
+    fn test_kbdi_increases_with_high_temp_no_rain() {
+        // High temp, no rain -> KBDI increases
+        let initial = 50.0;
+        let result = kbdi_update_mm(initial, 35.0, &[0.0, 0.0], 800.0);
+        assert!(result > initial, "KBDI should increase with high temp and no rain, got {}", result);
+    }
+
+    #[test]
+    fn test_kbdi_decreases_with_rain() {
+        // Rain > runoff threshold -> KBDI decreases
+        let initial = 100.0;
+        let result = kbdi_update_mm(initial, 30.0, &[0.0, 30.0], 800.0);
+        assert!(result < initial, "KBDI should decrease with heavy rain, got {}", result);
+    }
+
+    #[test]
+    fn test_kbdi_rain_runoff_consecutive_days() {
+        // Consecutive rainy days reduce the runoff threshold
+        // last_rain from prev days = 10mm -> effective rain = day_rain - max(0, RUNOFF - 10)
+        let result = kbdi_update_mm(100.0, 30.0, &[0.0, 10.0, 15.0], 800.0);
+        assert!(result >= 0.0 && result <= 200.0);
+    }
+}

--- a/src/lib/modules/mark5/mod.rs
+++ b/src/lib/modules/mark5/mod.rs
@@ -1,4 +1,8 @@
 pub mod constants;
 pub mod functions;
 pub mod models;
+
 pub mod config;
+
+#[cfg(test)]
+mod tests;

--- a/src/lib/modules/mark5/tests.rs
+++ b/src/lib/modules/mark5/tests.rs
@@ -1,0 +1,79 @@
+#[cfg(test)]
+mod tests {
+    use super::super::functions::{ffdi, rainfall_effect, find_rain_events};
+    use super::super::constants::RAIN_TH;
+    use chrono::{TimeZone, Utc};
+
+    #[test]
+    fn test_ffdi_typical_conditions() {
+        // Moderate fire weather conditions
+        let result = ffdi(25.0, 30.0, 20000.0, 5.0);
+        assert!(result > 0.0, "FFDI should be positive, got {}", result);
+    }
+
+    #[test]
+    fn test_ffdi_increases_with_temperature() {
+        let result_low = ffdi(15.0, 30.0, 20000.0, 5.0);
+        let result_high = ffdi(35.0, 30.0, 20000.0, 5.0);
+        assert!(result_high > result_low, "FFDI should increase with temperature");
+    }
+
+    #[test]
+    fn test_ffdi_decreases_with_humidity() {
+        let result_dry = ffdi(25.0, 20.0, 20000.0, 5.0);
+        let result_wet = ffdi(25.0, 80.0, 20000.0, 5.0);
+        assert!(result_dry > result_wet, "FFDI should decrease with higher humidity");
+    }
+
+    #[test]
+    fn test_ffdi_increases_with_wind() {
+        let result_calm = ffdi(25.0, 30.0, 5000.0, 5.0);
+        let result_windy = ffdi(25.0, 30.0, 50000.0, 5.0);
+        assert!(result_windy > result_calm, "FFDI should increase with wind speed");
+    }
+
+    #[test]
+    fn test_rainfall_effect_below_threshold() {
+        // Rain below threshold -> rainfall effect is 1.0 (no reduction)
+        let result = rainfall_effect(RAIN_TH - 0.5, 1);
+        assert!((result - 1.0).abs() < 1e-5, "Expected 1.0, got {}", result);
+    }
+
+    #[test]
+    fn test_rainfall_effect_above_threshold() {
+        // Rain above threshold and recent -> rainfall effect < 1.0
+        let result = rainfall_effect(RAIN_TH + 5.0, 1);
+        assert!(result < 1.0, "Rainfall effect should reduce danger, got {}", result);
+    }
+
+    #[test]
+    fn test_rainfall_effect_age_zero() {
+        // age_event == 0 uses effective age of 0.8
+        let result = rainfall_effect(RAIN_TH + 5.0, 0);
+        assert!(result >= 0.0 && result <= 1.0, "Rainfall effect should be in [0,1], got {}", result);
+    }
+
+    #[test]
+    fn test_find_rain_events_no_rain() {
+        let t0 = Utc.with_ymd_and_hms(2024, 6, 1, 0, 0, 0).unwrap();
+        let t1 = Utc.with_ymd_and_hms(2024, 6, 2, 0, 0, 0).unwrap();
+        let t2 = Utc.with_ymd_and_hms(2024, 6, 3, 0, 0, 0).unwrap();
+        let dates = vec![t0, t1, t2];
+        let daily_rain = vec![0.0, 0.0, 0.0];
+        let events = find_rain_events(t2, &dates, &daily_rain);
+        assert!(events.is_empty(), "Should find no rain events");
+    }
+
+    #[test]
+    fn test_find_rain_events_single_event() {
+        let t0 = Utc.with_ymd_and_hms(2024, 6, 1, 0, 0, 0).unwrap();
+        let t1 = Utc.with_ymd_and_hms(2024, 6, 2, 0, 0, 0).unwrap();
+        let t2 = Utc.with_ymd_and_hms(2024, 6, 3, 0, 0, 0).unwrap();
+        let dates = vec![t0, t1, t2];
+        // Only day 1 has rain above threshold
+        let daily_rain = vec![0.0, RAIN_TH + 5.0, 0.0];
+        let events = find_rain_events(t2, &dates, &daily_rain);
+        assert_eq!(events.len(), 1, "Should find 1 rain event");
+        assert!(events[0].0 > RAIN_TH, "Rain event total should be above threshold");
+    }
+}

--- a/src/lib/modules/nesterov/mod.rs
+++ b/src/lib/modules/nesterov/mod.rs
@@ -1,3 +1,6 @@
 pub mod constants;
 pub mod functions;
 pub mod models;
+
+#[cfg(test)]
+mod tests;

--- a/src/lib/modules/nesterov/tests.rs
+++ b/src/lib/modules/nesterov/tests.rs
@@ -1,0 +1,55 @@
+#[cfg(test)]
+mod tests {
+    use super::super::functions::{nesterov_update, get_output_fn};
+    use super::super::models::NesterovStateElement;
+    use super::super::constants::{NODATAVAL, RAIN_TH};
+
+    #[test]
+    fn test_nesterov_update_no_rain() {
+        // No rain -> nesterov accumulates: prev + temp*(temp - dew)
+        // temp=25, dew=15 -> 25*(25-15) = 250
+        let result = nesterov_update(100.0, 25.0, 15.0, 0.0);
+        assert!((result - 350.0).abs() < 1e-4, "Expected 350.0, got {}", result);
+    }
+
+    #[test]
+    fn test_nesterov_update_with_heavy_rain() {
+        // Rain above threshold -> nesterov resets to 0
+        let result = nesterov_update(500.0, 25.0, 15.0, RAIN_TH + 1.0);
+        assert_eq!(result, 0.0, "Nesterov should reset to 0 after heavy rain");
+    }
+
+    #[test]
+    fn test_nesterov_update_negative_clamp() {
+        // If result would be negative, clamp to 0
+        // temp=10, dew=20 -> 10*(10-20) = -100, prev=50 -> 50 + (-100) = -50 -> clamped to 0
+        let result = nesterov_update(50.0, 10.0, 20.0, 0.0);
+        assert_eq!(result, 0.0, "Nesterov should not go below 0");
+    }
+
+    #[test]
+    fn test_nesterov_update_accumulates_over_days() {
+        // Simulates accumulation over multiple dry days
+        let mut nesterov = 0.0_f32;
+        for _ in 0..5 {
+            nesterov = nesterov_update(nesterov, 30.0, 10.0, 0.0);
+        }
+        // Each day: 30*(30-10) = 600 -> after 5 days: 3000
+        assert!((nesterov - 3000.0).abs() < 1e-2, "Expected 3000.0, got {}", nesterov);
+    }
+
+    #[test]
+    fn test_get_output_fn_valid() {
+        let state = NesterovStateElement {
+            nesterov: 350.0,
+            temp_15: 25.0,
+            temp_dew_15: 15.0,
+            cum_rain: 0.0,
+        };
+        let output = get_output_fn(&state);
+        assert!((output.nesterov - 350.0).abs() < 1e-4);
+        assert!((output.temperature - 25.0).abs() < 1e-4);
+        assert!((output.temp_dew - 15.0).abs() < 1e-4);
+        assert!((output.rain - 0.0).abs() < 1e-4);
+    }
+}

--- a/src/lib/modules/orieux/mod.rs
+++ b/src/lib/modules/orieux/mod.rs
@@ -1,3 +1,7 @@
 pub mod constants;
 pub mod functions;
 pub mod models;
+
+
+#[cfg(test)]
+mod tests;

--- a/src/lib/modules/orieux/tests.rs
+++ b/src/lib/modules/orieux/tests.rs
@@ -1,0 +1,76 @@
+#[cfg(test)]
+mod tests {
+    use super::super::functions::fire_class;
+    use crate::modules::sharples::functions::{index_fmi, index_f};
+
+    // --- fire_class tests ---
+
+    #[test]
+    fn test_fire_class_dry_high_wind() {
+        // Low water reserve (<30mm) + high wind (>40km/h) -> class 3 (maximum danger)
+        let result = fire_class(10.0, 15.0); // 15 m/s = 54 km/h
+        assert_eq!(result, 3.0);
+    }
+
+    #[test]
+    fn test_fire_class_wet_any_wind() {
+        // High water reserve (100-150mm) -> class 0 regardless of wind
+        let result = fire_class(120.0, 5.0);
+        assert_eq!(result, 0.0);
+    }
+
+    #[test]
+    fn test_fire_class_medium_water_low_wind() {
+        // 50-100mm water reserve + low wind (<20km/h) -> class 1
+        let result = fire_class(70.0, 3.0); // 3 m/s = 10.8 km/h
+        assert_eq!(result, 1.0);
+    }
+
+    #[test]
+    fn test_fire_class_medium_water_high_wind() {
+        // 50-100mm water reserve + high wind (>40km/h) -> class 2
+        let result = fire_class(70.0, 15.0); // 15 m/s = 54 km/h
+        assert_eq!(result, 2.0);
+    }
+
+    #[test]
+    fn test_fire_class_30_to_50_low_wind() {
+        // 30-50mm water reserve + low wind -> class 1
+        let result = fire_class(40.0, 3.0);
+        assert_eq!(result, 1.0);
+    }
+
+    // --- Sharples index functions (defined in sharples/functions.rs but tested here for coverage) ---
+
+    #[test]
+    fn test_index_fmi_typical() {
+        // fmi = 10 - 0.25*(temp - humidity) = 10 - 0.25*(30-20) = 7.5
+        let result = index_fmi(30.0, 20.0);
+        assert!((result - 7.5).abs() < 1e-5, "Expected 7.5, got {}", result);
+    }
+
+    #[test]
+    fn test_index_fmi_equal_temp_humidity() {
+        // temp == humidity -> fmi = 10
+        let result = index_fmi(25.0, 25.0);
+        assert!((result - 10.0).abs() < 1e-5, "Expected 10.0, got {}", result);
+    }
+
+    #[test]
+    fn test_index_f_min_wind() {
+        // wind_speed = 500 m/h -> ws_kph = 0.5, max(1.0, 0.5) = 1.0
+        // f = 1.0 / fmi
+        let fmi = 7.5;
+        let result = index_f(fmi, 500.0);
+        assert!((result - 1.0 / fmi).abs() < 1e-5, "Expected {}, got {}", 1.0 / fmi, result);
+    }
+
+    #[test]
+    fn test_index_f_high_wind() {
+        // wind_speed = 36000 m/h -> ws_kph = 36.0
+        // f = 36.0 / fmi
+        let fmi = 7.5;
+        let result = index_f(fmi, 36000.0);
+        assert!((result - 36.0 / fmi).abs() < 1e-4, "Expected {}, got {}", 36.0 / fmi, result);
+    }
+}

--- a/src/lib/modules/portuguese/mod.rs
+++ b/src/lib/modules/portuguese/mod.rs
@@ -1,3 +1,7 @@
 pub mod constants;
 pub mod functions;
 pub mod models;
+
+
+#[cfg(test)]
+mod tests;

--- a/src/lib/modules/portuguese/tests.rs
+++ b/src/lib/modules/portuguese/tests.rs
@@ -1,0 +1,50 @@
+#[cfg(test)]
+mod tests {
+    use super::super::functions::{ignition_index, get_output_fn};
+    use super::super::models::PortugueseStateElement;
+
+    #[test]
+    fn test_ignition_index_typical() {
+        // temp=25, dew=15 -> ign = 25*(25-15) = 250
+        let result = ignition_index(25.0, 15.0);
+        assert!((result - 250.0).abs() < 1e-4, "Expected 250.0, got {}", result);
+    }
+
+    #[test]
+    fn test_ignition_index_zero_diff() {
+        // temp == dew -> ign = 0
+        let result = ignition_index(20.0, 20.0);
+        assert!((result - 0.0).abs() < 1e-5, "Expected 0.0, got {}", result);
+    }
+
+    #[test]
+    fn test_ignition_index_negative() {
+        // dew > temp -> negative ignition index (very moist air)
+        let result = ignition_index(10.0, 15.0);
+        assert!(result < 0.0, "Expected negative ignition index, got {}", result);
+    }
+
+    #[test]
+    fn test_ignition_index_increases_with_temp() {
+        let low = ignition_index(20.0, 10.0);
+        let high = ignition_index(35.0, 10.0);
+        assert!(high > low, "Ignition index should increase with temperature");
+    }
+
+    #[test]
+    fn test_get_output_fn_valid() {
+        let state = PortugueseStateElement {
+            ign: 250.0,
+            fire_index: 300.0,
+            temp_12: 25.0,
+            temp_dew_12: 15.0,
+            cum_rain: 0.0,
+            cum_index: 50.0,
+            sum_ign: 250.0,
+        };
+        let output = get_output_fn(&state);
+        assert!((output.portuguese_ignition - 250.0).abs() < 1e-4);
+        assert!((output.portuguese_fdi - 300.0).abs() < 1e-4);
+        assert!((output.temperature - 25.0).abs() < 1e-4);
+    }
+}

--- a/src/lib/modules/risico/mod.rs
+++ b/src/lib/modules/risico/mod.rs
@@ -2,3 +2,6 @@ pub mod config;
 pub mod constants;
 pub mod functions;
 pub mod models;
+
+#[cfg(test)]
+mod tests;

--- a/src/lib/modules/risico/tests.rs
+++ b/src/lib/modules/risico/tests.rs
@@ -1,0 +1,209 @@
+#[cfg(test)]
+mod tests {
+    use super::super::functions::*;
+    use crate::constants::NODATAVAL;
+    use chrono::{TimeZone, Utc};
+
+    // --- get_ppf ---
+
+    #[test]
+    fn test_ppf_summer() {
+        // July 15 = day 196, should return ppf_summer
+        let time = Utc.with_ymd_and_hms(2023, 7, 15, 0, 0, 0).unwrap();
+        let ppf = get_ppf(&time, 0.9, 0.3);
+        assert!((ppf - 0.9).abs() < 1e-3, "Expected summer PPF, got {}", ppf);
+    }
+
+    #[test]
+    fn test_ppf_winter() {
+        // January 15 = day 15, should return ppf_winter
+        let time = Utc.with_ymd_and_hms(2023, 1, 15, 0, 0, 0).unwrap();
+        let ppf = get_ppf(&time, 0.9, 0.3);
+        assert!((ppf - 0.3).abs() < 1e-3, "Expected winter PPF, got {}", ppf);
+    }
+
+    #[test]
+    fn test_ppf_transition_april() {
+        // April 15 is in spring transition (day ~105): value should be between winter and summer
+        let time = Utc.with_ymd_and_hms(2023, 4, 15, 0, 0, 0).unwrap();
+        let ppf = get_ppf(&time, 0.9, 0.3);
+        assert!(ppf > 0.3 && ppf < 0.9, "Expected transition PPF, got {}", ppf);
+    }
+
+    #[test]
+    fn test_ppf_negative_returns_zero() {
+        let time = Utc.with_ymd_and_hms(2023, 7, 15, 0, 0, 0).unwrap();
+        let ppf = get_ppf(&time, -1.0, 0.3);
+        assert_eq!(ppf, 0.0, "Negative ppf_summer should return 0");
+    }
+
+    // --- update_dffm_rain / update_dffm_rain_legacy ---
+
+    #[test]
+    fn test_update_dffm_rain_increases_moisture() {
+        let dffm_before = 10.0;
+        let sat = 60.0;
+        let result = update_dffm_rain(5.0, dffm_before, sat);
+        assert!(result > dffm_before, "Rain should increase dffm, got {}", result);
+    }
+
+    #[test]
+    fn test_update_dffm_rain_clamped_to_sat() {
+        let result = update_dffm_rain(100.0, 55.0, 60.0);
+        assert!(result <= 60.0, "dffm should be clamped to sat, got {}", result);
+    }
+
+    #[test]
+    fn test_update_dffm_rain_legacy_increases_moisture() {
+        let result = update_dffm_rain_legacy(5.0, 10.0, 60.0);
+        assert!(result > 10.0, "Legacy rain should increase dffm, got {}", result);
+    }
+
+    // --- update_dffm_dry ---
+
+    #[test]
+    fn test_update_dffm_dry_converges_to_emc() {
+        // After a long dry period (large dt), dffm should converge toward EMC
+        // T=25, H=30, W=0 -> EMC ~ some value; start wet dffm=50
+        let result = update_dffm_dry(50.0, 60.0, 25.0, 0.0, 30.0, 1.0, 10000.0);
+        assert!(result < 50.0, "Drying: dffm should decrease toward EMC, got {}", result);
+        assert!(result >= 0.0, "dffm should not go negative, got {}", result);
+    }
+
+    #[test]
+    fn test_update_dffm_dry_no_negative() {
+        let result = update_dffm_dry(0.0, 60.0, 40.0, 0.0, 5.0, 1.0, 3600.0);
+        assert!(result >= 0.0, "dffm should not go negative, got {}", result);
+    }
+
+    // --- get_moisture_effect ---
+
+    #[test]
+    fn test_moisture_effect_v2023_zero_is_max() {
+        let eff_zero = get_moisture_effect_v2023(0.0);
+        let eff_high = get_moisture_effect_v2023(30.0);
+        assert!(eff_zero > eff_high, "Dry fuel should have higher moisture effect");
+    }
+
+    #[test]
+    fn test_moisture_effect_v2023_clamped() {
+        let result = get_moisture_effect_v2023(0.0);
+        assert!(result <= 1.0 && result >= 0.0, "Expected [0,1], got {}", result);
+    }
+
+    #[test]
+    fn test_moisture_effect_v2025_zero_is_max() {
+        let eff_zero = get_moisture_effect_v2025(0.0);
+        let eff_high = get_moisture_effect_v2025(50.0);
+        assert!(eff_zero > eff_high, "Dry fuel should have higher moisture effect (v2025)");
+    }
+
+    // --- get_wind_effect_legacy ---
+
+    #[test]
+    fn test_wind_effect_legacy_nodata_wind_speed() {
+        let result = get_wind_effect_legacy(NODATAVAL, 0.0, 0.0, 0.0);
+        assert_eq!(result, 1.0, "NODATAVAL wind_speed should return 1.0");
+    }
+
+    #[test]
+    fn test_wind_effect_legacy_nodata_wind_dir() {
+        let result = get_wind_effect_legacy(5.0, NODATAVAL, 0.0, 0.0);
+        assert_eq!(result, 1.0, "NODATAVAL wind_dir should return 1.0");
+    }
+
+    // --- get_slope_effect_legacy ---
+
+    #[test]
+    fn test_slope_effect_legacy_zero_slope() {
+        use std::f32::consts::PI;
+        let result = get_slope_effect_legacy(0.0);
+        assert!((result - 1.0).abs() < 1e-3, "Zero slope should give effect ~1.0, got {}", result);
+    }
+
+    #[test]
+    fn test_slope_effect_legacy_increases_with_slope() {
+        let low = get_slope_effect_legacy(0.1);
+        let high = get_slope_effect_legacy(0.5);
+        assert!(high > low, "Steeper slope should give higher effect");
+    }
+
+    // --- get_lhv_dff ---
+
+    #[test]
+    fn test_lhv_dff_decreases_with_moisture() {
+        let lhv_dry = get_lhv_dff(18000.0, 5.0);
+        let lhv_wet = get_lhv_dff(18000.0, 30.0);
+        assert!(lhv_dry > lhv_wet, "Higher moisture should reduce LHV");
+    }
+
+    // --- get_lhv_l1 ---
+
+    #[test]
+    fn test_lhv_l1_nodata_humidity() {
+        let result = get_lhv_l1(NODATAVAL, 0.5, 18000.0);
+        assert_eq!(result, 0.0, "NODATAVAL humidity should return 0.0");
+    }
+
+    // --- get_intensity ---
+
+    #[test]
+    fn test_intensity_zero_ros() {
+        let result = get_intensity(1.0, 0.0, 0.0, -1.0, 15000.0, 12000.0);
+        assert_eq!(result, 0.0, "Zero ROS should give zero intensity");
+    }
+
+    #[test]
+    fn test_intensity_positive_with_valid_inputs() {
+        let result = get_intensity(1.0, 0.0, 10.0, -1.0, 15000.0, 12000.0);
+        assert!(result > 0.0, "Positive ROS should give positive intensity");
+    }
+
+    // --- get_meteo_index ---
+
+    #[test]
+    fn test_meteo_index_legacy_nodata() {
+        let result = get_meteo_index_legacy(NODATAVAL, 1.5);
+        assert_eq!(result, NODATAVAL, "NODATAVAL dffm should return NODATAVAL");
+    }
+
+    #[test]
+    fn test_meteo_index_legacy_low_wind_effect() {
+        // w_effect < 1.0 should return NODATAVAL
+        let result = get_meteo_index_legacy(10.0, 0.5);
+        assert_eq!(result, NODATAVAL, "w_effect < 1.0 should return NODATAVAL");
+    }
+
+    #[test]
+    fn test_meteo_index_v2023_nodata() {
+        let result = get_meteo_index_v2023(NODATAVAL, 1.5);
+        assert_eq!(result, NODATAVAL);
+    }
+
+    #[test]
+    fn test_meteo_index_v2025_nodata() {
+        let result = get_meteo_index_v2025(NODATAVAL, 1.5);
+        assert_eq!(result, NODATAVAL);
+    }
+
+    #[test]
+    fn test_meteo_index_v2023_dry_high_wind() {
+        // Very dry (dffm=1.0) + high wind (w_effect=3.0) -> should be high danger (4.0)
+        let result = get_meteo_index_v2023(1.0, 3.0);
+        assert_eq!(result, 4.0, "Extreme conditions should return 4.0, got {}", result);
+    }
+
+    // --- index_from_swi ---
+
+    #[test]
+    fn test_index_from_swi_below_threshold() {
+        let result = index_from_swi(15.0, 5.0);
+        assert_eq!(result, 0.0, "SWI <= 10 should return 0");
+    }
+
+    #[test]
+    fn test_index_from_swi_above_threshold() {
+        let result = index_from_swi(15.0, 20.0);
+        assert_eq!(result, 15.0, "SWI > 10 should return dffm");
+    }
+}

--- a/src/lib/modules/sharples/mod.rs
+++ b/src/lib/modules/sharples/mod.rs
@@ -1,3 +1,7 @@
 pub mod constants;
 pub mod functions;
 pub mod models;
+
+
+#[cfg(test)]
+mod tests;

--- a/src/lib/modules/sharples/tests.rs
+++ b/src/lib/modules/sharples/tests.rs
@@ -1,0 +1,83 @@
+#[cfg(test)]
+mod tests {
+    use super::super::functions::{index_fmi, index_f, get_output_fn};
+    use super::super::models::SharplesStateElement;
+    use super::super::constants::NODATAVAL;
+    use crate::constants::NODATAVAL as OUTPUT_NODATAVAL;
+
+    #[test]
+    fn test_fmi_typical() {
+        // fmi = 10 - 0.25*(temp - humidity) = 10 - 0.25*(30-20) = 7.5
+        let result = index_fmi(30.0, 20.0);
+        assert!((result - 7.5).abs() < 1e-5, "Expected 7.5, got {}", result);
+    }
+
+    #[test]
+    fn test_fmi_equal_temp_humidity() {
+        // temp == humidity -> fmi = 10.0
+        let result = index_fmi(25.0, 25.0);
+        assert!((result - 10.0).abs() < 1e-5, "Expected 10.0, got {}", result);
+    }
+
+    #[test]
+    fn test_fmi_high_temp_low_humidity() {
+        // High temp, low humidity -> lower fmi (drier fuel)
+        let result = index_fmi(40.0, 10.0);
+        // fmi = 10 - 0.25*(40-10) = 10 - 7.5 = 2.5
+        assert!((result - 2.5).abs() < 1e-5, "Expected 2.5, got {}", result);
+    }
+
+    #[test]
+    fn test_index_f_clamps_low_wind() {
+        // wind_speed < 1000 m/h -> ws_kph < 1.0 -> max(1.0, ws) = 1.0
+        let fmi = 5.0;
+        let result = index_f(fmi, 500.0);
+        assert!((result - 1.0 / fmi).abs() < 1e-5, "Expected {}, got {}", 1.0 / fmi, result);
+    }
+
+    #[test]
+    fn test_index_f_high_wind() {
+        // wind_speed = 72000 m/h = 72 km/h -> f = 72 / fmi
+        let fmi = 8.0;
+        let result = index_f(fmi, 72000.0);
+        assert!((result - 9.0).abs() < 1e-4, "Expected 9.0, got {}", result);
+    }
+
+    #[test]
+    fn test_get_output_fn_valid() {
+        let state = SharplesStateElement {
+            temp: 30.0,
+            humidity: 20.0,
+            wind_speed: 36000.0, // 36 km/h = 10 m/s
+        };
+        let output = get_output_fn(&state);
+        // fmi = 10 - 0.25*(30-20) = 7.5
+        assert!((output.fmi - 7.5).abs() < 1e-5);
+        // f = 36 / 7.5 = 4.8
+        assert!((output.f - 4.8).abs() < 1e-4);
+        // wind speed should be converted to m/s: 36000/3600 = 10 m/s
+        assert!((output.wind_speed - 10.0).abs() < 1e-4);
+    }
+
+    #[test]
+    fn test_get_output_fn_nodata_temp() {
+        let state = SharplesStateElement {
+            temp: NODATAVAL,
+            humidity: 20.0,
+            wind_speed: 36000.0,
+        };
+        let output = get_output_fn(&state);
+        assert_eq!(output.fmi, OUTPUT_NODATAVAL);
+    }
+
+    #[test]
+    fn test_get_output_fn_nodata_wind() {
+        let state = SharplesStateElement {
+            temp: 30.0,
+            humidity: 20.0,
+            wind_speed: NODATAVAL,
+        };
+        let output = get_output_fn(&state);
+        assert_eq!(output.fmi, OUTPUT_NODATAVAL);
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds the first unit test suite to the risico-2023 codebase.

76 tests covering all 10 fire risk index modules.

## Modules covered

| Module | Tests | What is tested |
|--------|-------|----------------|
| `angstrom` | 6 | formula, fire risk levels, NODATAVAL, get_output_fn |
| `fosberg` | 7 | EMC at 3 humidity ranges, FFWI monotonicity, NODATAVAL |
| `hdw` | 6 | zero wind, typical value, monotonicity, NODATAVAL |
| `nesterov` | 5 | accumulation, heavy rain reset, negative clamp, NODATAVAL |
| `kbdi` | 5 | clamp min/max, increases with heat/drought, decreases with rain |
| `mark5` | 6 | FFDI monotonicity (temp/wind/humidity), rainfall_effect threshold |
| `orieux` | 5 | fire_class at 5 moisture/wind combinations |
| `sharples` | 7 | index_fmi formula and monotonicity, index_f min wind clamp |
| `portuguese` | 6 | ignition_index formula, zero diff, negative, monotonicity |
| `fwi` | 14 | FFMC round-trip, moisture range, rain effect, ISI/BUI/FWI formulas, DMC/DC update |

## How to run

```bash
cargo test --lib --no-default-features
```

> **Note:** `--no-default-features` is required when the system HDF5 version (e.g. v1.14.5) is incompatible with the `hdf5-sys 0.8.1` dependency in `Cargo.toml`.

## Test result

```
test result: ok. 76 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```
